### PR TITLE
Change generated input array type to signed char instead of char

### DIFF
--- a/maze-gen/CVE-neg_gen.py
+++ b/maze-gen/CVE-neg_gen.py
@@ -17,7 +17,7 @@ class Generator:
                     break
 
     def get_logic_def(self):
-        logic_def = "char read_input(char *input, int index){ return input[index]; }\n"
+        logic_def = "signed char read_input(signed char *input, int index){ return input[index]; }\n"
         return logic_def
 
     def get_numb_edges(self, idx):
@@ -57,10 +57,10 @@ class Generator:
             logic = ""
             copy_idx = 0
             for var in vars:
-                logic += "\t\tchar {} = read_input(copy, {});\n".format(var, copy_idx)
+                logic += "\t\tsigned char {} = read_input(copy, {});\n".format(var, copy_idx)
                 copy_idx += 1
             for i in range(len(new_vars)):
-                logic += "\t\tchar {} = read_input(copy, {});\n".format(new_vars[i], copy_idx)
+                logic += "\t\tsigned char {} = read_input(copy, {});\n".format(new_vars[i], copy_idx)
                 copy_idx += 1
             logic += "\t\tint flag = 0;\n"
             if self.insert[idx] == 0:

--- a/maze-gen/CVE_gen.py
+++ b/maze-gen/CVE_gen.py
@@ -16,7 +16,7 @@ class Generator:
                 if sum(self.insert) >= len(self.groups):
                     break
     def get_logic_def(self):
-        logic_def = "char read_input(char *input, int index){ return input[index]; }\n"
+        logic_def = "signed char read_input(signed char *input, int index){ return input[index]; }\n"
         return logic_def
 
     def get_logic_c(self):
@@ -24,7 +24,7 @@ class Generator:
         group_idx = 0
         for idx in range(self.size):
             if self.insert[idx] == 0:
-                logic_c.append("\t\tchar c = read_input(copy, 0);")
+                logic_c.append("\t\tsigned char c = read_input(copy, 0);")
             else:
                 copy_idx, tab_cnt = 0, 0
                 constraints, vars = set(), set()
@@ -33,9 +33,9 @@ class Generator:
                     vars = vars.union(self.vars[group_idx + cnt])
                 buggy_constraints = ""
                 for var in vars:
-                    buggy_constraints += "\t\tchar {} = read_input(copy, {});\n".format(var, copy_idx)
+                    buggy_constraints += "\t\tsigned char {} = read_input(copy, {});\n".format(var, copy_idx)
                     copy_idx += 1
-                buggy_constraints += "\t\tchar c = read_input(copy, {});\n".format(len(vars))
+                buggy_constraints += "\t\tsigned char c = read_input(copy, {});\n".format(len(vars))
                 buggy_constraints += "\t\tint flag = 0;\n"
                 for constraint in constraints:
                     buggy_constraints += "\t"*tab_cnt + "\t\tif{}{{\n".format(constraint)

--- a/maze-gen/array_to_code.py
+++ b/maze-gen/array_to_code.py
@@ -127,34 +127,34 @@ def render_program(c_file, maze, maze_funcs, width, height, generator, sln, smt_
     "#include <unistd.h>\n" \
     "#include <stdint.h>\n")
     f.write("""#define MAX_LIMIT {}\n\n""".format(total_bytes))
-    function_format_declaration = """void func_{}(char *input, int index, int length);\n"""
+    function_format_declaration = """void func_{}(signed char *input, int index, int length);\n"""
     function_declarations = ""
     for k in range(width*height):
         function_declarations += function_format_declaration.format(k)
     f.write(function_declarations)
-    f.write("""void func_start(char *input, int index, int length){}\n""")
-    f.write("""void func_bug(char *input, int index, int length){{ {} }}\n""".format(bug))
+    f.write("""void func_start(signed char *input, int index, int length){}\n""")
+    f.write("""void func_bug(signed char *input, int index, int length){{ {} }}\n""".format(bug))
     f.write(logic_def)
-    f.write("""char* copy_input(char *input, int index, int bytes_to_use){
-    char *copy;
-    copy = (char*)malloc(bytes_to_use);
+    f.write("""signed char* copy_input(signed char *input, int index, int bytes_to_use){
+    signed char *copy;
+    copy = (signed char*)malloc(bytes_to_use);
     if (copy == NULL){
     \tprintf("Failed memory allocation");
     \texit(1);
     }
     memcpy(copy, input + index, bytes_to_use);
-    return (char*)copy;\n}\n""")
-    f.write("""int is_within_limit(char *input, int index, int bytes_to_use, int length){
+    return (signed char*)copy;\n}\n""")
+    f.write("""int is_within_limit(signed char *input, int index, int bytes_to_use, int length){
     if (index + (bytes_to_use - 1) >= MAX_LIMIT || index + (bytes_to_use - 1) >= length){
     \treturn 0;
     } else {
     \treturn 1;
     }\n}\n""")
 
-    function_begin_format = """void func_{}(char *input, int index, int length){{
+    function_begin_format = """void func_{}(signed char *input, int index, int length){{
     int bytes_to_use = {};
     if (is_within_limit(input, index, bytes_to_use, length)){{
-    \tchar *copy;
+    \tsigned char *copy;
     \tcopy = copy_input(input, index, bytes_to_use);\n {}
     \tfree(copy);
     \tcopy = NULL;
@@ -188,7 +188,7 @@ def render_program(c_file, maze, maze_funcs, width, height, generator, sln, smt_
         f.write(function_end)
 
     f.write("""int main(){{
-    char input[MAX_LIMIT];
+    signed char input[MAX_LIMIT];
     int input_length = read(0, input, MAX_LIMIT);
     int index = 0;
     func_{}(input, index, input_length);\n}}\n""".format(maze_funcs[(0, 0)]))

--- a/maze-gen/default_gen.py
+++ b/maze-gen/default_gen.py
@@ -5,13 +5,13 @@ class Generator:
         self.sln = sln
 
     def get_logic_def(self):
-        logic_def = "char read_input(char *input, int index){ return input[index]; }\n\n"
+        logic_def = "signed char read_input(signed char *input, int index){ return input[index]; }\n\n"
         return logic_def
 
     def get_logic_c(self):
         logic_c = list()
         for idx in range(self.size):
-            logic_c.append("\t\tchar c = read_input(copy, 0);")
+            logic_c.append("\t\tsigned char c = read_input(copy, 0);")
         return logic_c
 
     def get_numb_bytes(self):

--- a/maze-gen/equality0_gen.py
+++ b/maze-gen/equality0_gen.py
@@ -7,13 +7,13 @@ class Generator:
         self.sln = sln
 
     def get_logic_def(self):
-        logic_def = "char read_input(char *input, int index){ return input[index]; }\n\n"
+        logic_def = "signed char read_input(signed char *input, int index){ return input[index]; }\n\n"
         return logic_def
 
     def get_logic_c(self):
         logic_c = list()
         for idx in range(self.size):
-            logic_c.append("\t\tchar c = read_input(copy, 0);")
+            logic_c.append("\t\tsigned char c = read_input(copy, 0);")
         return logic_c
 
     def get_numb_bytes(self):

--- a/maze-gen/equality100_gen.py
+++ b/maze-gen/equality100_gen.py
@@ -7,13 +7,13 @@ class Generator:
         self.sln = sln
 
     def get_logic_def(self):
-        logic_def = "char read_input(char *input, int index){ return input[index]; }\n\n"
+        logic_def = "signed char read_input(signed char *input, int index){ return input[index]; }\n\n"
         return logic_def
 
     def get_logic_c(self):
         logic_c = list()
         for idx in range(self.size):
-            logic_c.append("\t\tchar c = read_input(copy, 0);")
+            logic_c.append("\t\tsigned char c = read_input(copy, 0);")
         return logic_c
 
     def get_numb_bytes(self):

--- a/maze-gen/equality25_gen.py
+++ b/maze-gen/equality25_gen.py
@@ -7,13 +7,13 @@ class Generator:
         self.sln = sln
 
     def get_logic_def(self):
-        logic_def = "char read_input(char *input, int index){ return input[index]; }\n\n"
+        logic_def = "signed char read_input(signed char *input, int index){ return input[index]; }\n\n"
         return logic_def
 
     def get_logic_c(self):
         logic_c = list()
         for idx in range(self.size):
-            logic_c.append("\t\tchar c = read_input(copy, 0);")
+            logic_c.append("\t\tsigned char c = read_input(copy, 0);")
         return logic_c
 
     def get_numb_bytes(self):

--- a/maze-gen/equality50_gen.py
+++ b/maze-gen/equality50_gen.py
@@ -7,13 +7,13 @@ class Generator:
         self.sln = sln
 
     def get_logic_def(self):
-        logic_def = "char read_input(char *input, int index){ return input[index]; }\n\n"
+        logic_def = "signed char read_input(signed char *input, int index){ return input[index]; }\n\n"
         return logic_def
 
     def get_logic_c(self):
         logic_c = list()
         for idx in range(self.size):
-            logic_c.append("\t\tchar c = read_input(copy, 0);")
+            logic_c.append("\t\tsigned char c = read_input(copy, 0);")
         return logic_c
 
     def get_numb_bytes(self):

--- a/maze-gen/equality75_gen.py
+++ b/maze-gen/equality75_gen.py
@@ -7,13 +7,13 @@ class Generator:
         self.sln = sln
 
     def get_logic_def(self):
-        logic_def = "char read_input(char *input, int index){ return input[index]; }\n\n"
+        logic_def = "signed char read_input(signed char *input, int index){ return input[index]; }\n\n"
         return logic_def
 
     def get_logic_c(self):
         logic_c = list()
         for idx in range(self.size):
-            logic_c.append("\t\tchar c = read_input(copy, 0);")
+            logic_c.append("\t\tsigned char c = read_input(copy, 0);")
         return logic_c
 
     def get_numb_bytes(self):


### PR DESCRIPTION
Since the size of char in c is platform dependent it makes more sense to make its type explicitly signed. 
Some of the generated conditions compare the input with negative numbers, thus defining the input as a signed char array makes more sense than leaving this up to the platform. 